### PR TITLE
Add Haycraft-Queen Cornerstones metadata

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -45,6 +45,8 @@
 		<meta id="collection-1" property="belongs-to-collection">Sherlock Holmes</meta>
 		<meta property="collection-type" refines="#collection-1">series</meta>
 		<meta property="group-position" refines="#collection-1">1</meta>
+		<meta id="collection-2" property="belongs-to-collection">Haycraft-Queen Cornerstones</meta>
+		<meta property="collection-type" refines="#collection-2">set</meta>
 		<dc:description id="description">The self-declared world’s first consulting detective unravels a mysterious case of murder and revenge.</dc:description>
 		<meta id="long-description" property="se:long-description" refines="#description">
 			&lt;p&gt;&lt;i&gt;A Study in Scarlet&lt;/i&gt; is the novel which first introduced &lt;a href="https://standardebooks.org/ebooks/arthur-conan-doyle"&gt;Arthur Conan Doyles’&lt;/a&gt; iconic characters Sherlock Holmes and &lt;abbr&gt;Dr.&lt;/abbr&gt; Watson. It was published in 1887 in a popular magazine, &lt;i&gt;Beeton’s Christmas Annual&lt;/i&gt;. It attracted little public attention at the time, but interest in Holmes continued to build with the subsequent series of short stories Doyle wrote featuring the austere, analytical detective—now one of the most well-known characters in all of English literature.&lt;/p&gt;


### PR DESCRIPTION
Note that while A Study in Scarlet is missing in the [top Google result for Haycraft-Queen Cornerstones ](http://www.classiccrimefiction.com/haycraftqueen.htm) it is listed in the original source, Murder For Pleasure by Howard Haycraft. See the page scans here: https://archive.org/details/in.ernet.dli.2015.225635/page/n351